### PR TITLE
Refactor meal plan API and clean Next.js config

### DIFF
--- a/Nutrishop/nutrishop-v2/next.config.mjs
+++ b/Nutrishop/nutrishop-v2/next.config.mjs
@@ -1,8 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    appDir: true
-  }
-}
+const nextConfig = {}
 
 export default nextConfig

--- a/Nutrishop/nutrishop-v2/src/app/api/ai/generate-plan/route.ts
+++ b/Nutrishop/nutrishop-v2/src/app/api/ai/generate-plan/route.ts
@@ -1,38 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 import { generateMealPlan } from '@/lib/gemini'
 import { buildMealPlanPrompt } from '@/lib/prompts'
 import { isValidDateRange, hasValidMealDates } from '@/lib/date-utils'
 import { z } from 'zod'
-
-export const sessionFetcher = { get: getServerSession }
-
-export const mealPlanSchema = z.object({
-  days: z.array(z.object({
-    date: z.string(),
-    meals: z.array(z.object({
-      name: z.string(),
-      description: z.string().optional(),
-      instructions: z.array(z.string()),
-      prepTime: z.coerce.number().optional(),
-      cookTime: z.coerce.number().optional(),
-      servings: z.coerce.number().optional(),
-      difficulty: z.string().optional(),
-      type: z.string(),
-      nutrition: z.object({
-        kcal: z.coerce.number(),
-        protein: z.coerce.number(),
-        carbs: z.coerce.number(),
-        fat: z.coerce.number(),
-        fiber: z.coerce.number(),
-        sugar: z.coerce.number(),
-        sodium: z.coerce.number()
-      })
-    }))
-  }))
-})
+import {
+  sessionFetcher,
+  mealPlanSchema,
+  datesWithinRange,
+  saveMealPlan,
+} from '@/lib/meal-plan'
 
 export async function POST(req: NextRequest) {
   try {
@@ -125,101 +103,4 @@ export async function POST(req: NextRequest) {
       { status: 500 }
     )
   }
-}
-
-export function datesWithinRange(
-  days: Array<{ date: string }>,
-  startDate: string,
-  endDate: string
-) {
-  const start = new Date(startDate).getTime()
-  const end = new Date(endDate).getTime()
-  return days.every((day) => {
-    const time = new Date(day.date).getTime()
-    return time >= start && time <= end
-  })
-}
-
-export async function saveMealPlan(
-  validMealPlan: {
-    days: Array<{
-      date: string
-      meals: Array<{
-        name: string
-        description?: string
-        instructions: string[]
-        prepTime?: number
-        cookTime?: number
-        servings?: number
-        difficulty?: string
-        type: string
-        nutrition: {
-          kcal: number
-          protein: number
-          carbs: number
-          fat: number
-          fiber: number
-          sugar: number
-          sodium: number
-        }
-      }>
-    }>
-  },
-  profile: any,
-  userId: string,
-  startDate: string,
-  endDate: string
-) {
-  return prisma.$transaction(async (tx) => {
-    const plan = await tx.plan.create({
-      data: {
-        userId,
-        startDate: new Date(startDate),
-        endDate: new Date(endDate),
-      },
-    })
-
-    const tasks: Promise<unknown>[] = []
-    for (const day of validMealPlan.days) {
-      for (const meal of day.meals) {
-        const task = tx.recipe
-          .upsert({
-            where: { userId_name: { userId, name: meal.name } },
-            update: {},
-            create: {
-              userId,
-              name: meal.name,
-              description: meal.description,
-              instructions: Array.isArray(meal.instructions) ? meal.instructions.join('\n') : '',
-              prepTime: meal.prepTime,
-              cookTime: meal.cookTime,
-              servings: meal.servings,
-              difficulty: meal.difficulty,
-              kcal: meal.nutrition.kcal,
-              protein: meal.nutrition.protein,
-              carbs: meal.nutrition.carbs,
-              fat: meal.nutrition.fat,
-              fiber: meal.nutrition.fiber,
-              sugar: meal.nutrition.sugar,
-              sodium: meal.nutrition.sodium,
-              tags: [profile.cuisineType || 'classique'],
-              category: meal.type,
-            },
-          })
-          .then((recipe) =>
-            tx.menuItem.create({
-              data: {
-                planId: plan.id,
-                date: new Date(day.date),
-                mealType: meal.type,
-                recipeId: recipe.id,
-              },
-            })
-          )
-        tasks.push(task)
-      }
-    }
-    await Promise.all(tasks)
-    return plan
-  })
 }

--- a/Nutrishop/nutrishop-v2/src/lib/meal-plan.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/meal-plan.ts
@@ -1,0 +1,132 @@
+import { getServerSession } from 'next-auth'
+import { prisma } from '@/lib/db'
+import { z } from 'zod'
+
+export const sessionFetcher = { get: getServerSession }
+
+export const mealPlanSchema = z.object({
+  days: z.array(
+    z.object({
+      date: z.string(),
+      meals: z.array(
+        z.object({
+          name: z.string(),
+          description: z.string().optional(),
+          instructions: z.array(z.string()),
+          prepTime: z.coerce.number().optional(),
+          cookTime: z.coerce.number().optional(),
+          servings: z.coerce.number().optional(),
+          difficulty: z.string().optional(),
+          type: z.string(),
+          nutrition: z.object({
+            kcal: z.coerce.number(),
+            protein: z.coerce.number(),
+            carbs: z.coerce.number(),
+            fat: z.coerce.number(),
+            fiber: z.coerce.number(),
+            sugar: z.coerce.number(),
+            sodium: z.coerce.number(),
+          }),
+        })
+      ),
+    })
+  ),
+})
+
+export function datesWithinRange(
+  days: Array<{ date: string }>,
+  startDate: string,
+  endDate: string
+) {
+  const start = new Date(startDate).getTime()
+  const end = new Date(endDate).getTime()
+  return days.every((day) => {
+    const time = new Date(day.date).getTime()
+    return time >= start && time <= end
+  })
+}
+
+export async function saveMealPlan(
+  validMealPlan: {
+    days: Array<{
+      date: string
+      meals: Array<{
+        name: string
+        description?: string
+        instructions: string[]
+        prepTime?: number
+        cookTime?: number
+        servings?: number
+        difficulty?: string
+        type: string
+        nutrition: {
+          kcal: number
+          protein: number
+          carbs: number
+          fat: number
+          fiber: number
+          sugar: number
+          sodium: number
+        }
+      }>
+    }>
+  },
+  profile: any,
+  userId: string,
+  startDate: string,
+  endDate: string
+) {
+  return prisma.$transaction(async (tx) => {
+    const plan = await tx.plan.create({
+      data: {
+        userId,
+        startDate: new Date(startDate),
+        endDate: new Date(endDate),
+      },
+    })
+
+    const tasks: Promise<unknown>[] = []
+    for (const day of validMealPlan.days) {
+      for (const meal of day.meals) {
+        const task = tx.recipe
+          .upsert({
+            where: { userId_name: { userId, name: meal.name } },
+            update: {},
+            create: {
+              userId,
+              name: meal.name,
+              description: meal.description,
+              instructions: Array.isArray(meal.instructions) ? meal.instructions.join('\n') : '',
+              prepTime: meal.prepTime,
+              cookTime: meal.cookTime,
+              servings: meal.servings,
+              difficulty: meal.difficulty,
+              kcal: meal.nutrition.kcal,
+              protein: meal.nutrition.protein,
+              carbs: meal.nutrition.carbs,
+              fat: meal.nutrition.fat,
+              fiber: meal.nutrition.fiber,
+              sugar: meal.nutrition.sugar,
+              sodium: meal.nutrition.sodium,
+              tags: [profile.cuisineType || 'classique'],
+              category: meal.type,
+            },
+          })
+          .then((recipe) =>
+            tx.menuItem.create({
+              data: {
+                planId: plan.id,
+                date: new Date(day.date),
+                mealType: meal.type,
+                recipeId: recipe.id,
+              },
+            })
+          )
+        tasks.push(task)
+      }
+    }
+    await Promise.all(tasks)
+    return plan
+  })
+}
+


### PR DESCRIPTION
## Summary
- move meal plan schema and helpers to a shared lib module and import them in the API route
- remove deprecated `experimental.appDir` flag from Next.js config
- update tests to rely on the new utility module

## Testing
- `npm test`
- `npm run build`
- `npx tsc --noEmit`
- `npm audit` (fails: command requires an existing lockfile)
- `npm run lint` (fails: Missing script: "lint")

------
https://chatgpt.com/codex/tasks/task_e_68a4b3cc2e1c832ba44c7bcb590ecfc0