### PR TITLE
Improve robustness and security

### DIFF
--- a/Nutrishop/nutrishop-v2/src/app/api/ai/generate-plan/route.ts
+++ b/Nutrishop/nutrishop-v2/src/app/api/ai/generate-plan/route.ts
@@ -11,6 +11,7 @@ import {
   datesWithinRange,
   saveMealPlan,
 } from '@/lib/meal-plan'
+import { rateLimit } from '@/middleware/rate-limit'
 
 const requestSchema = z.object({
   startDate: z.string().refine(isValidDate, {
@@ -23,6 +24,10 @@ const requestSchema = z.object({
 
 export async function POST(req: NextRequest) {
   try {
+    const limit = rateLimit(req)
+    if (!limit.ok) {
+      return NextResponse.json({ error: 'Too many requests' }, { status: 429 })
+    }
     const contentType = req.headers.get('content-type') || ''
     if (!contentType.includes('application/json')) {
       return NextResponse.json({ error: 'Unsupported Media Type' }, { status: 415 })

--- a/Nutrishop/nutrishop-v2/src/lib/__tests__/db.test.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/__tests__/db.test.ts
@@ -9,3 +9,17 @@ test('db throws without DATABASE_URL', () => {
   assert.notEqual(result.status, 0)
   assert.match(result.stderr.toString(), /DATABASE_URL is required/)
 })
+
+test('disconnects prisma on beforeExit', () => {
+  const code = `
+    (async () => {
+      process.env.DATABASE_URL='postgresql://user:pass@localhost:5432/test'
+      const { prisma } = await import('./src/lib/db.ts')
+      prisma.$disconnect = () => { console.log('disconnected'); return Promise.resolve() }
+      process.emit('beforeExit', 0)
+    })()
+  `
+  const result = spawnSync(process.execPath, ['-r', 'tsx', '-e', code])
+  assert.equal(result.status, 0)
+  assert.match(result.stdout.toString(), /disconnected/)
+})

--- a/Nutrishop/nutrishop-v2/src/lib/__tests__/gemini.test.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/__tests__/gemini.test.ts
@@ -83,3 +83,29 @@ test('analyzeNutrition rejects incomplete data', async () => {
   await assert.rejects(() => analyzeNutrition('bad'), /Invalid nutrition analysis format/)
   setModel(null)
 })
+
+test('generateMealPlan rejects oversized responses', async () => {
+  process.env.GOOGLE_API_KEY = 'test'
+  process.env.GEMINI_MODEL = 'test-model'
+  const { generateMealPlan, setModel, MAX_RESPONSE_LENGTH } = await import(modulePath)
+  const large = 'a'.repeat(MAX_RESPONSE_LENGTH + 1)
+  const mockModel: ReturnType<GoogleGenerativeAI['getGenerativeModel']> = {
+    generateContent: async () => ({ response: { text: () => large } }) as any
+  } as any
+  setModel(mockModel)
+  await assert.rejects(() => generateMealPlan('prompt'), /Gemini response too large/)
+  setModel(null)
+})
+
+test('analyzeNutrition rejects oversized responses', async () => {
+  process.env.GOOGLE_API_KEY = 'test'
+  process.env.GEMINI_MODEL = 'test-model'
+  const { analyzeNutrition, setModel, MAX_RESPONSE_LENGTH } = await import(modulePath)
+  const large = 'a'.repeat(MAX_RESPONSE_LENGTH + 1)
+  const mockModel: ReturnType<GoogleGenerativeAI['getGenerativeModel']> = {
+    generateContent: async () => ({ response: { text: () => large } }) as any
+  } as any
+  setModel(mockModel)
+  await assert.rejects(() => analyzeNutrition('food'), /Gemini response too large/)
+  setModel(null)
+})

--- a/Nutrishop/nutrishop-v2/src/lib/__tests__/optimizer-limit.test.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/__tests__/optimizer-limit.test.ts
@@ -1,0 +1,13 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+test('throws when combinations exceed limit', async () => {
+  process.env.MAX_STORE_COMBINATIONS = '1'
+  const { optimizeShopping } = await import('../optimizer')
+  const needs = [{ id: '1', name: 'a', quantity: 1, unit: 'unit' }]
+  const offers = [
+    { storeId: 's1', productId: 'p', storeName: 'S1', productName: 'a', price: 1, unit: 'unit', quantity: 1 },
+    { storeId: 's2', productId: 'p', storeName: 'S2', productName: 'a', price: 1, unit: 'unit', quantity: 1 },
+  ]
+  assert.throws(() => optimizeShopping(needs, offers, 2), /Too many store combinations/)
+})

--- a/Nutrishop/nutrishop-v2/src/lib/__tests__/rate-limit.test.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/__tests__/rate-limit.test.ts
@@ -1,0 +1,14 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { NextRequest } from 'next/server'
+import { rateLimit } from '../../middleware/rate-limit'
+
+test('rateLimit blocks after threshold', () => {
+  const req = new NextRequest('http://test')
+  for (let i = 0; i < 5; i++) {
+    const res = rateLimit(req)
+    assert.ok(res.ok)
+  }
+  const res = rateLimit(req)
+  assert.ok(!res.ok)
+})

--- a/Nutrishop/nutrishop-v2/src/lib/__tests__/register.test.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/__tests__/register.test.ts
@@ -9,7 +9,7 @@ import { Prisma } from '@prisma/client'
 const requestBody = {
   email: 'a@a.com',
   username: 'user',
-  password: 'secret1'
+  password: 'Secret1!'
 }
 
 test('handles unique constraint conflicts', async () => {
@@ -51,7 +51,7 @@ test('normalizes email and username casing before persistence', async () => {
 
   const req = new NextRequest('http://test', {
     method: 'POST',
-    body: JSON.stringify({ email: ' TeSt@Example.COM ', username: ' UsEr ', password: 'secret1' }),
+    body: JSON.stringify({ email: ' TeSt@Example.COM ', username: ' UsEr ', password: 'Secret1!' }),
     headers: { 'content-type': 'application/json' }
   })
   await POST(req)
@@ -88,4 +88,16 @@ test('returns 415 on invalid Content-Type', async () => {
   })
   const res = await POST(req)
   assert.equal(res.status, 415)
+})
+
+test('returns 400 on weak password', async () => {
+  const { POST } = await import('../../app/api/auth/register/route')
+  const weak = { ...requestBody, password: 'weakpass' }
+  const req = new NextRequest('http://test', {
+    method: 'POST',
+    body: JSON.stringify(weak),
+    headers: { 'content-type': 'application/json' }
+  })
+  const res = await POST(req)
+  assert.equal(res.status, 400)
 })

--- a/Nutrishop/nutrishop-v2/src/lib/db.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/db.ts
@@ -20,3 +20,14 @@ export function getPrisma() {
 export const prisma = getPrisma()
 
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+
+const disconnect = async () => {
+  try {
+    await prisma.$disconnect()
+  } catch (error) {
+    console.error('Error disconnecting Prisma', error)
+  }
+}
+
+process.once('beforeExit', disconnect)
+process.once('SIGTERM', disconnect)

--- a/Nutrishop/nutrishop-v2/src/lib/optimizer.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/optimizer.ts
@@ -46,6 +46,10 @@ export interface OptimizationResult {
   recommendations: string[]
 }
 
+export const MAX_STORE_COMBINATIONS = Number(
+  process.env.MAX_STORE_COMBINATIONS || '100000'
+)
+
 // Convertir les unités en unités de base pour la comparaison
 const weightUnits: Record<string, number> = {
   kg: 1000,
@@ -246,9 +250,12 @@ function findBestStoreCombination(
   // Générer toutes les combinaisons possibles de magasins
   const storeIds = Array.from(storeOffers.keys())
   const combinations: string[][] = []
-  
+
   for (let k = 1; k <= Math.min(maxStores, storeIds.length); k++) {
     generateCombinations(storeIds, k, 0, [], combinations)
+    if (combinations.length > MAX_STORE_COMBINATIONS) {
+      throw new Error('Too many store combinations')
+    }
   }
   
   let bestResult: Omit<OptimizationResult, 'recommendations'> | null = null

--- a/Nutrishop/nutrishop-v2/src/middleware/rate-limit.ts
+++ b/Nutrishop/nutrishop-v2/src/middleware/rate-limit.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from 'next/server'
+
+interface RateRecord {
+  count: number
+  expires: number
+}
+
+const WINDOW_MS = 60_000
+const MAX_REQUESTS = 5
+const store = new Map<string, RateRecord>()
+
+function getIP(req: NextRequest) {
+  return (
+    req.headers.get('x-forwarded-for')?.split(',')[0] ||
+    (req as any).ip ||
+    '127.0.0.1'
+  )
+}
+
+export function rateLimit(
+  req: NextRequest,
+  limit: number = MAX_REQUESTS,
+  windowMs: number = WINDOW_MS
+) {
+  const ip = getIP(req)
+  const now = Date.now()
+  const record = store.get(ip)
+  if (!record || now > record.expires) {
+    store.set(ip, { count: 1, expires: now + windowMs })
+    return { ok: true, remaining: limit - 1, reset: now + windowMs }
+  }
+  if (record.count >= limit) {
+    return { ok: false, remaining: 0, reset: record.expires }
+  }
+  record.count += 1
+  return { ok: true, remaining: limit - record.count, reset: record.expires }
+}


### PR DESCRIPTION
## Summary
- close Prisma connection on process exit events
- cap Gemini API response length and test oversize handling
- add in-memory rate limiting for registration and meal plan generation
- enforce stronger password policy
- guard against excessive store combinations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d7765e10832b8bbb14ca057914d4