### PR TITLE
Validate configs and tighten schemas

### DIFF
--- a/Nutrishop/nutrishop-v2/src/lib/meal-plan.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/meal-plan.ts
@@ -10,6 +10,8 @@ export interface MealPlanProfile {
 
 export const sessionFetcher = { get: getServerSession }
 
+export const mealTypes = ['breakfast', 'lunch', 'dinner'] as const
+
 export const mealPlanSchema = z.object({
   days: z.array(
     z.object({
@@ -23,7 +25,7 @@ export const mealPlanSchema = z.object({
           cookTime: z.coerce.number().optional(),
           servings: z.coerce.number().optional(),
           difficulty: z.string().optional(),
-          type: z.string(),
+          type: z.enum(mealTypes),
           nutrition: z.object({
             kcal: z.coerce.number(),
             protein: z.coerce.number(),
@@ -66,7 +68,7 @@ export async function saveMealPlan(
         cookTime?: number
         servings?: number
         difficulty?: string
-        type: string
+        type: (typeof mealTypes)[number]
         nutrition: {
           kcal: number
           protein: number

--- a/Nutrishop/nutrishop-v2/src/lib/optimizer.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/optimizer.ts
@@ -46,9 +46,14 @@ export interface OptimizationResult {
   recommendations: string[]
 }
 
-export const MAX_STORE_COMBINATIONS = Number(
-  process.env.MAX_STORE_COMBINATIONS || '100000'
+const parsedMaxStoreCombinations = parseInt(
+  process.env.MAX_STORE_COMBINATIONS ?? '100000',
+  10
 )
+
+export const MAX_STORE_COMBINATIONS = isNaN(parsedMaxStoreCombinations)
+  ? 100000
+  : parsedMaxStoreCombinations
 
 // Convertir les unités en unités de base pour la comparaison
 const weightUnits: Record<string, number> = {

--- a/Nutrishop/nutrishop-v2/src/lib/prompts.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/prompts.ts
@@ -11,8 +11,38 @@ export function buildMealPlanPrompt(
   const applianceList =
     profile.appliances?.map((a) => a.appliance.name).join(', ') || 'none'
 
+  const example = `
+{
+  "days": [
+    {
+      "date": "YYYY-MM-DD",
+      "meals": [
+        {
+          "type": "",
+          "name": "",
+          "description": "",
+          "instructions": [""],
+          "prepTime": 0,
+          "cookTime": 0,
+          "servings": 0,
+          "difficulty": "",
+          "nutrition": {
+            "kcal": 0,
+            "protein": 0,
+            "carbs": 0,
+            "fat": 0,
+            "fiber": 0,
+            "sugar": 0,
+            "sodium": 0
+          }
+        }
+      ]
+    }
+  ]
+}`.trim()
+
   return `Tu es un planificateur de repas. Crée un plan de repas du ${startDate} au ${endDate}.
 Cuisine préférée: ${profile.cuisineType || 'classique'}.
 Appareils disponibles: ${applianceList}.
-Réponds en JSON avec le format { "days": [ { "date": "YYYY-MM-DD", "meals": [ { "type": "", "name": "", "description": "", "instructions": [""], "prepTime": 0, "cookTime": 0, "servings": 0, "difficulty": "", "nutrition": { "kcal": 0, "protein": 0, "carbs": 0, "fat": 0, "fiber": 0, "sugar": 0, "sodium": 0 } } ] } ] }`
+Réponds en JSON avec le format ${example}`
 }

--- a/Nutrishop/nutrishop-v2/src/middleware/rate-limit.ts
+++ b/Nutrishop/nutrishop-v2/src/middleware/rate-limit.ts
@@ -26,12 +26,13 @@ setInterval(cleanup, WINDOW_MS).unref?.()
  * Falls back to 127.0.0.1 when no information is available.
  */
 function getIP(req: NextRequest) {
-  return (
+  const ip =
     req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
     req.headers.get('x-real-ip')?.trim() ||
-    (typeof (req as any).ip === 'string' ? (req as any).ip.trim() : (req as any).ip) ||
+    (req as any).ip ||
     '127.0.0.1'
-  )
+
+  return String(ip).trim()
 }
 
 export function rateLimit(


### PR DESCRIPTION
## Summary
- Ensure rate limiter always returns a string IP
- Guard MAX_STORE_COMBINATIONS against invalid env values
- Clean up meal plan prompt and enforce meal type enum

## Testing
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a561ce5bcc832b9a95a69e38fde2ca