### PR TITLE
Add request body limits, tighten auth validation, and improve reliability

### DIFF
--- a/Nutrishop/nutrishop-v2/src/lib/__tests__/gemini.test.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/__tests__/gemini.test.ts
@@ -62,6 +62,13 @@ test('parseMealPlanResponse rejects non-object JSON', async () => {
   assert.throws(() => parseMealPlanResponse('42'), /Invalid meal plan format/)
 })
 
+test('parseMealPlanResponse rejects arrays', async () => {
+  process.env.GOOGLE_API_KEY = 'test'
+  process.env.GEMINI_MODEL = 'test-model'
+  const { parseMealPlanResponse } = await import(modulePath)
+  assert.throws(() => parseMealPlanResponse('[1,2,3]'), /Invalid meal plan format/)
+})
+
 test('analyzeNutrition parses model response', async () => {
   process.env.GOOGLE_API_KEY = 'test'
   process.env.GEMINI_MODEL = 'test-model'

--- a/Nutrishop/nutrishop-v2/src/lib/__tests__/generate-plan.test.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/__tests__/generate-plan.test.ts
@@ -137,7 +137,7 @@ test('returns 413 on payload too large', async () => {
     body: large,
     headers: {
       'content-type': 'application/json',
-      'content-length': String(large.length),
+      'content-length': '10',
       'x-real-ip': '203.0.113.10'
     }
   })

--- a/Nutrishop/nutrishop-v2/src/lib/__tests__/rate-limit.test.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/__tests__/rate-limit.test.ts
@@ -44,3 +44,12 @@ test('trims whitespace in IP headers', () => {
   assert.equal(record?.count, 2)
   assert.equal(store.size, 1)
 })
+
+test('falls back to loopback on invalid IP header', () => {
+  store.clear()
+  const req = new Request('http://test', {
+    headers: { 'x-real-ip': 'bad-ip' },
+  })
+  rateLimit(req as any)
+  assert.ok(store.has('127.0.0.1'))
+})

--- a/Nutrishop/nutrishop-v2/src/lib/auth.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/auth.ts
@@ -5,8 +5,8 @@ import { compare } from 'bcryptjs'
 import { z } from 'zod'
 
 const credentialsSchema = z.object({
-  email: z.string(),
-  password: z.string()
+  email: z.string().trim().email(),
+  password: z.string().min(8),
 })
 export async function authorize(credentials: { email: string; password: string }) {
   const prisma = getPrisma()

--- a/Nutrishop/nutrishop-v2/src/lib/db.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/db.ts
@@ -28,7 +28,10 @@ const disconnect = async () => {
     console.error('Error disconnecting Prisma', error)
   }
 }
-
-process.once('beforeExit', disconnect)
-process.once('SIGTERM', disconnect)
-process.once('SIGINT', disconnect)
+const flag = '__prismaListenersRegistered'
+if (!(globalThis as any)[flag]) {
+  ;(globalThis as any)[flag] = true
+  process.once('beforeExit', disconnect)
+  process.once('SIGTERM', disconnect)
+  process.once('SIGINT', disconnect)
+}

--- a/Nutrishop/nutrishop-v2/src/lib/gemini.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/gemini.ts
@@ -35,9 +35,11 @@ export function parseMealPlanResponse(text: string) {
   const cleaned = text.replace(/```(?:json)?|```/gi, '').trim()
 
   const extracted = extract(cleaned)
-  if (Array.isArray(extracted) && extracted.length > 0) {
-    if (typeof extracted[0] === 'object' && extracted[0] !== null) {
-      return extracted[0]
+  if (Array.isArray(extracted)) {
+    for (const item of extracted) {
+      if (typeof item === 'object' && item !== null && !Array.isArray(item)) {
+        return item
+      }
     }
   }
 
@@ -45,14 +47,10 @@ export function parseMealPlanResponse(text: string) {
   const endObj = cleaned.lastIndexOf('}')
   if (startObj !== -1 && endObj !== -1) {
     try {
-      return JSON.parse(jsonrepair(cleaned.slice(startObj, endObj + 1)))
-    } catch {}
-  }
-  const startArr = cleaned.indexOf('[')
-  const endArr = cleaned.lastIndexOf(']')
-  if (startArr !== -1 && endArr !== -1) {
-    try {
-      return JSON.parse(jsonrepair(cleaned.slice(startArr, endArr + 1)))
+      const obj = JSON.parse(jsonrepair(cleaned.slice(startObj, endObj + 1)))
+      if (typeof obj === 'object' && obj !== null && !Array.isArray(obj)) {
+        return obj
+      }
     } catch {}
   }
 

--- a/Nutrishop/nutrishop-v2/src/lib/request.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/request.ts
@@ -1,0 +1,38 @@
+import { NextRequest } from 'next/server'
+
+export class PayloadTooLargeError extends Error {
+  constructor() {
+    super('Payload too large')
+  }
+}
+
+export class InvalidJsonError extends Error {
+  constructor() {
+    super('Invalid JSON')
+  }
+}
+
+export async function readJsonBody(req: NextRequest, maxBytes: number) {
+  const reader = req.body?.getReader()
+  if (!reader) {
+    throw new InvalidJsonError()
+  }
+  const decoder = new TextDecoder()
+  let size = 0
+  let text = ''
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    size += value.byteLength
+    if (size > maxBytes) {
+      throw new PayloadTooLargeError()
+    }
+    text += decoder.decode(value, { stream: true })
+  }
+  text += decoder.decode()
+  try {
+    return JSON.parse(text)
+  } catch {
+    throw new InvalidJsonError()
+  }
+}


### PR DESCRIPTION
## Summary
- enforce streamed request body size limits with reusable `readJsonBody`
- harden credential validation and ensure Prisma hooks register once
- validate rate-limit IP headers and require object responses from Gemini

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a59d6151c8832b81e5b83e3f8e5986