### PR TITLE
Add basic frontend and French error messages

### DIFF
--- a/Nutrishop/nutrishop-v2/src/app/api/auth/register/route.ts
+++ b/Nutrishop/nutrishop-v2/src/app/api/auth/register/route.ts
@@ -18,7 +18,7 @@ const registerSchema = z.object({
     .min(8)
     .regex(/(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[^A-Za-z0-9])/, {
       message:
-        'Password must be 8+ chars with upper, lower, number and symbol'
+        'Le mot de passe doit contenir au moins 8 caractères avec majuscule, minuscule, chiffre et symbole'
     })
 })
 
@@ -38,7 +38,7 @@ export async function POST(request: NextRequest) {
       json = await readJsonBody(request, maxBody)
     } catch (err) {
       if (err instanceof PayloadTooLargeError) {
-        return NextResponse.json({ error: 'Payload too large' }, { status: 413 })
+        return NextResponse.json({ error: 'Corps de requête trop volumineux' }, { status: 413 })
       }
       if (err instanceof InvalidJsonError) {
         return NextResponse.json({ error: 'Requête JSON invalide' }, { status: 400 })
@@ -93,7 +93,7 @@ export async function POST(request: NextRequest) {
     }
     return NextResponse.json({ success: true }, { status: 201 })
   } catch (error) {
-    console.error('Registration error:', error)
+    console.error("Erreur d'inscription:", error)
     return NextResponse.json(
       { error: "Une erreur est survenue lors de l'inscription" },
       { status: 500 }

--- a/Nutrishop/nutrishop-v2/src/app/layout.tsx
+++ b/Nutrishop/nutrishop-v2/src/app/layout.tsx
@@ -1,0 +1,11 @@
+export const metadata = {
+  title: 'Nutrishop'
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="fr">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/Nutrishop/nutrishop-v2/src/app/page.tsx
+++ b/Nutrishop/nutrishop-v2/src/app/page.tsx
@@ -1,0 +1,11 @@
+export default function Home() {
+  return (
+    <main>
+      <h1>Nutrishop</h1>
+      <ul>
+        <li><a href="/register">Inscription</a></li>
+        <li><a href="/plan">Plan repas</a></li>
+      </ul>
+    </main>
+  )
+}

--- a/Nutrishop/nutrishop-v2/src/app/plan/page.tsx
+++ b/Nutrishop/nutrishop-v2/src/app/plan/page.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import { useState } from 'react'
+
+export default function PlanPage() {
+  const [form, setForm] = useState({ startDate: '', endDate: '' })
+  const [error, setError] = useState<string | null>(null)
+  const [result, setResult] = useState<any>(null)
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setResult(null)
+    try {
+      const res = await fetch('/api/ai/generate-plan', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form)
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error || 'Erreur inconnue')
+      } else {
+        setResult(data)
+      }
+    } catch (err) {
+      setError('Erreur réseau')
+    }
+  }
+
+  return (
+    <main>
+      <h1>Générer un plan repas</h1>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="date"
+          name="startDate"
+          value={form.startDate}
+          onChange={handleChange}
+        />
+        <input
+          type="date"
+          name="endDate"
+          value={form.endDate}
+          onChange={handleChange}
+        />
+        <button type="submit">Envoyer</button>
+      </form>
+      {error && <p>{error}</p>}
+      {result && <pre>{JSON.stringify(result, null, 2)}</pre>}
+    </main>
+  )
+}

--- a/Nutrishop/nutrishop-v2/src/app/register/page.tsx
+++ b/Nutrishop/nutrishop-v2/src/app/register/page.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { useState } from 'react'
+
+export default function RegisterPage() {
+  const [form, setForm] = useState({ email: '', username: '', password: '' })
+  const [message, setMessage] = useState<string | null>(null)
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setMessage(null)
+    try {
+      const res = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form)
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setMessage(data.error || 'Erreur inconnue')
+      } else {
+        setMessage('Inscription réussie')
+      }
+    } catch (err) {
+      setMessage('Erreur réseau')
+    }
+  }
+
+  return (
+    <main>
+      <h1>Inscription</h1>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="email"
+          name="email"
+          value={form.email}
+          onChange={handleChange}
+          placeholder="Email"
+        />
+        <input
+          type="text"
+          name="username"
+          value={form.username}
+          onChange={handleChange}
+          placeholder="Nom d'utilisateur"
+        />
+        <input
+          type="password"
+          name="password"
+          value={form.password}
+          onChange={handleChange}
+          placeholder="Mot de passe"
+        />
+        <button type="submit">Envoyer</button>
+      </form>
+      {message && <p>{message}</p>}
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- Add simple registration and meal-plan pages to exercise backend APIs
- Translate API error messages to French for consistent responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5fa827f9c832ba025d7ad39684bba