### PR TITLE
feat: improve request handling and rate limiter

### DIFF
--- a/Nutrishop/nutrishop-v2/package-lock.json
+++ b/Nutrishop/nutrishop-v2/package-lock.json
@@ -24,6 +24,7 @@
         "clsx": "^2.0.0",
         "date-fns": "^2.30.0",
         "extract-json-from-string": "^1.0.1",
+        "ioredis": "^5.3.2",
         "jsonrepair": "^3.13.0",
         "lucide-react": "^0.294.0",
         "next": "14.2.32",
@@ -708,6 +709,12 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.3.0.tgz",
+      "integrity": "sha512-M/T6Zewn7sDaBQEqIZ8Rb+i9y8qfGmq+5SDFSf9sA2lUZTmdDLVdOiQaeDp+Q4wElZ9HG1GAX5KhDaidp6LQsQ==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -3202,6 +3209,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3479,7 +3495,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3540,6 +3555,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/detect-node-es": {
@@ -4905,6 +4929,30 @@
         "node": ">=12"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
+      "integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -5559,6 +5607,18 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -5667,7 +5727,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -6632,6 +6691,27 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -7015,6 +7095,12 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {

--- a/Nutrishop/nutrishop-v2/package.json
+++ b/Nutrishop/nutrishop-v2/package.json
@@ -31,6 +31,7 @@
     "clsx": "^2.0.0",
     "date-fns": "^2.30.0",
     "extract-json-from-string": "^1.0.1",
+    "ioredis": "^5.3.2",
     "jsonrepair": "^3.13.0",
     "lucide-react": "^0.294.0",
     "next": "14.2.32",

--- a/Nutrishop/nutrishop-v2/src/app/api/ai/generate-plan/route.ts
+++ b/Nutrishop/nutrishop-v2/src/app/api/ai/generate-plan/route.ts
@@ -30,7 +30,7 @@ const requestSchema = z.object({
 
 export async function POST(req: NextRequest) {
   try {
-    const limit = rateLimit(req)
+    const limit = await rateLimit(req)
     if (!limit.ok) {
       return NextResponse.json({ error: 'Trop de requêtes' }, { status: 429 })
     }

--- a/Nutrishop/nutrishop-v2/src/app/api/auth/register/route.ts
+++ b/Nutrishop/nutrishop-v2/src/app/api/auth/register/route.ts
@@ -24,7 +24,7 @@ const registerSchema = z.object({
 
 export async function POST(request: NextRequest) {
   try {
-    const limit = rateLimit(request)
+    const limit = await rateLimit(request)
     if (!limit.ok) {
       return NextResponse.json({ error: 'Trop de requêtes' }, { status: 429 })
     }

--- a/Nutrishop/nutrishop-v2/src/app/plan/page.tsx
+++ b/Nutrishop/nutrishop-v2/src/app/plan/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from 'react'
+import { fetchJson } from '@/lib/fetch-json'
 
 export default function PlanPage() {
   const [form, setForm] = useState({ startDate: '', endDate: '' })
@@ -15,20 +16,23 @@ export default function PlanPage() {
     e.preventDefault()
     setError(null)
     setResult(null)
+    if (!form.startDate || !form.endDate) {
+      setError('Les deux dates sont requises')
+      return
+    }
+    if (form.startDate > form.endDate) {
+      setError('La date de début doit précéder la date de fin')
+      return
+    }
     try {
-      const res = await fetch('/api/ai/generate-plan', {
+      const data = await fetchJson('/api/ai/generate-plan', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(form)
       })
-      const data = await res.json()
-      if (!res.ok) {
-        setError(data.error || 'Erreur inconnue')
-      } else {
-        setResult(data)
-      }
+      setResult(data)
     } catch (err) {
-      setError('Erreur réseau')
+      setError(err instanceof Error ? err.message : 'Erreur inconnue')
     }
   }
 
@@ -41,12 +45,16 @@ export default function PlanPage() {
           name="startDate"
           value={form.startDate}
           onChange={handleChange}
+          required
+          max={form.endDate || undefined}
         />
         <input
           type="date"
           name="endDate"
           value={form.endDate}
           onChange={handleChange}
+          required
+          min={form.startDate || undefined}
         />
         <button type="submit">Envoyer</button>
       </form>

--- a/Nutrishop/nutrishop-v2/src/app/register/page.tsx
+++ b/Nutrishop/nutrishop-v2/src/app/register/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from 'react'
+import { fetchJson } from '@/lib/fetch-json'
 
 export default function RegisterPage() {
   const [form, setForm] = useState({ email: '', username: '', password: '' })
@@ -14,19 +15,14 @@ export default function RegisterPage() {
     e.preventDefault()
     setMessage(null)
     try {
-      const res = await fetch('/api/auth/register', {
+      await fetchJson('/api/auth/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(form)
       })
-      const data = await res.json()
-      if (!res.ok) {
-        setMessage(data.error || 'Erreur inconnue')
-      } else {
-        setMessage('Inscription réussie')
-      }
+      setMessage('Inscription réussie')
     } catch (err) {
-      setMessage('Erreur réseau')
+      setMessage(err instanceof Error ? err.message : 'Erreur inconnue')
     }
   }
 

--- a/Nutrishop/nutrishop-v2/src/lib/fetch-json.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/fetch-json.ts
@@ -1,0 +1,18 @@
+export async function fetchJson(input: RequestInfo | URL, init?: RequestInit) {
+  const res = await fetch(input, init)
+  const contentType = res.headers.get('content-type') || ''
+  if (!contentType.includes('application/json')) {
+    const text = await res.text().catch(() => '')
+    throw new Error(text || 'Réponse non JSON du serveur')
+  }
+  let data: any
+  try {
+    data = await res.json()
+  } catch {
+    throw new Error('Réponse JSON invalide')
+  }
+  if (!res.ok) {
+    throw new Error(data?.error || 'Erreur inconnue')
+  }
+  return data
+}

--- a/Nutrishop/nutrishop-v2/src/lib/redis.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/redis.ts
@@ -1,0 +1,19 @@
+import Redis from 'ioredis'
+
+let client: Redis | null = null
+
+export function getRedis() {
+  const url = process.env.REDIS_URL
+  if (!url) return null
+  if (!client) {
+    client = new Redis(url)
+  }
+  return client
+}
+
+export async function disconnectRedis() {
+  if (client) {
+    await client.quit()
+    client = null
+  }
+}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Ce projet contient une application Next.js située dans `Nutrishop/nutrishop-v2`
    - `DATABASE_URL`
    - `GOOGLE_API_KEY`
    - `GEMINI_MODEL`
+   - `REDIS_URL` (facultatif, pour la limitation de débit)
 4. Générer le client Prisma:
    ```bash
    npm run db:generate


### PR DESCRIPTION
## Summary
- improve JSON response handling for register and meal-plan forms
- validate meal plan dates on the client
- add Redis-backed rate limiter with optional in-memory fallback

## Testing
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a615a856a4832b85603ed12154f2a2