### PR TITLE
refactor: centralize rate limit and config

### DIFF
--- a/Nutrishop/nutrishop-v2/src/lib/__tests__/generate-plan.test.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/__tests__/generate-plan.test.ts
@@ -2,6 +2,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { getPrisma } from '../db'
 import { differenceInCalendarDays } from 'date-fns'
+import { DEFAULT_MAX_JSON_SIZE } from '../api-utils'
 const prisma = getPrisma()
 
 const mealPlan = {
@@ -131,7 +132,7 @@ test('returns 413 on payload too large', async () => {
   const session = await import(`../session?t=${Date.now()}`)
   session.setSessionGetter(async () => ({ user: { id: '1', email: 'a@a.com', name: 'user' } }))
   const route = await import(`../../app/api/ai/generate-plan/route?t=${Date.now()}`)
-  const large = 'a'.repeat(1_000_001)
+  const large = 'a'.repeat(DEFAULT_MAX_JSON_SIZE + 1)
   const req = new Request('http://test', {
     method: 'POST',
     body: large,

--- a/Nutrishop/nutrishop-v2/src/lib/__tests__/rate-limit.test.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/__tests__/rate-limit.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { rateLimit, rateLimitByIP, store, cleanup } from '../../middleware/rate-limit'
+import { rateLimit, rateLimitByIP, store, cleanup } from '../rate-limit'
 
 test('rateLimit blocks after threshold', async () => {
   store.clear()

--- a/Nutrishop/nutrishop-v2/src/lib/__tests__/register.test.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/__tests__/register.test.ts
@@ -4,7 +4,8 @@ import bcrypt from 'bcryptjs'
 import { getPrisma } from '../db'
 const prisma = getPrisma()
 import { Prisma } from '@prisma/client'
-import { store, rateLimitByIP } from '../../middleware/rate-limit'
+import { store, rateLimitByIP } from '../rate-limit'
+import { DEFAULT_MAX_JSON_SIZE } from '../api-utils'
 
 const requestBody = {
   email: 'a@a.com',
@@ -154,7 +155,7 @@ test('returns 415 on invalid Content-Type', async () => {
 test('returns 413 on payload too large', async () => {
   store.clear()
   const { POST } = await import('../../app/api/auth/register/route')
-  const large = 'a'.repeat(1_000_001)
+  const large = 'a'.repeat(DEFAULT_MAX_JSON_SIZE + 1)
   const req = new Request('http://test', {
     method: 'POST',
     body: large,

--- a/Nutrishop/nutrishop-v2/src/lib/api-utils.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/api-utils.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from 'next/server'
+import { parseJsonRequest } from './http'
+
+export const DEFAULT_MAX_JSON_SIZE = 1_000_000
+
+export async function parseJsonBody<T>(
+  req: Request | NextRequest,
+  options?: { maxBytes?: number }
+) {
+  const maxBytes = options?.maxBytes ?? DEFAULT_MAX_JSON_SIZE
+  return parseJsonRequest<T>(req as NextRequest, maxBytes)
+}

--- a/Nutrishop/nutrishop-v2/src/lib/auth.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/auth.ts
@@ -3,16 +3,14 @@ import CredentialsProvider from 'next-auth/providers/credentials'
 import { getPrisma } from './db'
 import { compare } from 'bcryptjs'
 import { z } from 'zod'
-import { rateLimitByIP } from '@/middleware/rate-limit'
-import { getIP } from './ip'
+import { rateLimit } from './rate-limit'
 
 const credentialsSchema = z.object({
   email: z.string().trim().email(),
   password: z.string().min(8),
 })
 export async function authorize(credentials: { email: string; password: string }, req?: Request | any) {
-  const ip = getIP(req)
-  const limit = await rateLimitByIP(ip)
+  const limit = await rateLimit(req)
   if (!limit.ok) throw new Error('Too many attempts')
   const prisma = getPrisma()
   const email = credentials.email.trim().toLowerCase()

--- a/Nutrishop/nutrishop-v2/src/lib/config.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/config.ts
@@ -8,28 +8,11 @@ const envSchema = z.object({
   MAX_STORE_COMBINATIONS: z.coerce.number().int().positive().default(100000),
 })
 
-const env = envSchema.parse(process.env)
+let env: z.infer<typeof envSchema>
 
-export function getDatabaseUrl() {
-  if (!env.DATABASE_URL) throw new Error('DATABASE_URL is required')
-  try {
-    new URL(env.DATABASE_URL)
-  } catch {
-    throw new Error('DATABASE_URL is invalid')
+export function getEnv() {
+  if (!env) {
+    env = envSchema.parse(process.env)
   }
-  return env.DATABASE_URL
-}
-
-export function getRedisUrl() {
-  return env.REDIS_URL
-}
-
-export function getGeminiConfig() {
-  if (!env.GOOGLE_API_KEY) throw new Error('GOOGLE_API_KEY is required')
-  if (!env.GEMINI_MODEL) throw new Error('GEMINI_MODEL is required')
-  return { apiKey: env.GOOGLE_API_KEY, model: env.GEMINI_MODEL }
-}
-
-export function getMaxStoreCombinations() {
-  return env.MAX_STORE_COMBINATIONS
+  return env
 }

--- a/Nutrishop/nutrishop-v2/src/lib/db.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/db.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from '@prisma/client'
-import { getDatabaseUrl } from './config'
+import { getEnv } from './config'
 
 const globalForPrisma = globalThis as unknown as {
   prisma?: PrismaClient
@@ -7,9 +7,15 @@ const globalForPrisma = globalThis as unknown as {
 
 export function getPrisma() {
   if (!globalForPrisma.prisma) {
-    const databaseUrl = getDatabaseUrl()
+    const { DATABASE_URL } = getEnv()
+    if (!DATABASE_URL) throw new Error('DATABASE_URL is required')
+    try {
+      new URL(DATABASE_URL)
+    } catch {
+      throw new Error('DATABASE_URL is invalid')
+    }
     globalForPrisma.prisma = new PrismaClient({
-      datasources: { db: { url: databaseUrl } }
+      datasources: { db: { url: DATABASE_URL } }
     })
   }
   return globalForPrisma.prisma

--- a/Nutrishop/nutrishop-v2/src/lib/errors.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/errors.ts
@@ -3,6 +3,7 @@ export const JSON_INVALIDE = 'Requête JSON invalide'
 export const REPONSE_NON_JSON = 'Réponse non JSON du serveur'
 export const REPONSE_JSON_INVALIDE = 'Réponse JSON invalide'
 export const ERREUR_INCONNUE = 'Erreur inconnue'
+export const TOO_MANY_REQUESTS = 'Trop de requêtes'
 
 export class PayloadTooLargeError extends Error {
   constructor() {

--- a/Nutrishop/nutrishop-v2/src/lib/gemini.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/gemini.ts
@@ -2,7 +2,7 @@ import { GoogleGenerativeAI } from '@google/generative-ai'
 import { z } from 'zod'
 import extract from 'extract-json-from-string'
 import { jsonrepair } from 'jsonrepair'
-import { getGeminiConfig } from './config'
+import { getEnv } from './config'
 import { mealPlanSchema, type MealPlan } from './meal-plan'
 
 let model: ReturnType<GoogleGenerativeAI['getGenerativeModel']> | null = null
@@ -17,9 +17,11 @@ export function setModel(
 
 function getModel() {
   if (!model) {
-    const { apiKey, model: modelName } = getGeminiConfig()
-    const genAI = new GoogleGenerativeAI(apiKey)
-    model = genAI.getGenerativeModel({ model: modelName })
+    const { GOOGLE_API_KEY, GEMINI_MODEL } = getEnv()
+    if (!GOOGLE_API_KEY) throw new Error('GOOGLE_API_KEY is required')
+    if (!GEMINI_MODEL) throw new Error('GEMINI_MODEL is required')
+    const genAI = new GoogleGenerativeAI(GOOGLE_API_KEY)
+    model = genAI.getGenerativeModel({ model: GEMINI_MODEL })
   }
   return model
 }

--- a/Nutrishop/nutrishop-v2/src/lib/optimizer.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/optimizer.ts
@@ -1,4 +1,4 @@
-import { getMaxStoreCombinations } from './config'
+import { getEnv } from './config'
 
 export interface ShoppingNeed {
   id: string
@@ -48,7 +48,7 @@ export interface OptimizationResult {
   recommendations: string[]
 }
 
-export const MAX_STORE_COMBINATIONS = getMaxStoreCombinations()
+export const MAX_STORE_COMBINATIONS = getEnv().MAX_STORE_COMBINATIONS
 
 // Convertir les unités en unités de base pour la comparaison
 const weightUnits: Record<string, number> = {

--- a/Nutrishop/nutrishop-v2/src/lib/rate-limit.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/rate-limit.ts
@@ -1,6 +1,6 @@
-import { NextRequest } from 'next/server'
-import { getRedis } from '@/lib/redis'
-import { getIP } from '@/lib/ip'
+import type { NextRequest } from 'next/server'
+import { getRedis } from './redis'
+import { getIP } from './ip'
 
 interface RateRecord {
   count: number
@@ -65,7 +65,7 @@ export async function rateLimitByIP(
 }
 
 export async function rateLimit(
-  req: NextRequest,
+  req?: Request | NextRequest,
   limit: number = MAX_REQUESTS,
   windowMs: number = WINDOW_MS
 ) {

--- a/Nutrishop/nutrishop-v2/src/lib/redis.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/redis.ts
@@ -1,10 +1,10 @@
 import Redis from 'ioredis'
-import { getRedisUrl } from './config'
+import { getEnv } from './config'
 
 let client: Redis | null = null
 
 export function getRedis() {
-  const url = getRedisUrl()
+  const { REDIS_URL: url } = getEnv()
   if (!url) return null
   if (!client) {
     try {


### PR DESCRIPTION
## Summary
- move rate limiting into lib and allow Request or NextRequest
- centralize JSON body parsing with default size limit
- introduce unified env loader and shared "Too many requests" error message

## Testing
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a80864add0832b8cf598607e525f93