### PR TITLE
Refactor API utilities and error handling

### DIFF
--- a/Nutrishop/nutrishop-v2/src/lib/__tests__/rate-limit.test.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/__tests__/rate-limit.test.ts
@@ -38,7 +38,7 @@ test('uses x-real-ip header when present', async () => {
   })
   const res = await rateLimit(req as any)
   assert.ok(res.ok)
-  assert.ok(store.has('203.0.113.1'))
+  assert.ok(store.has('203.0.113.1:/'))
 })
 
 test('trims whitespace in IP headers', async () => {
@@ -51,7 +51,7 @@ test('trims whitespace in IP headers', async () => {
   })
   await rateLimit(req1 as any)
   await rateLimit(req2 as any)
-  const record = store.get('203.0.113.1')
+  const record = store.get('203.0.113.1:/')
   assert.equal(record?.count, 2)
   assert.equal(store.size, 1)
 })
@@ -62,5 +62,5 @@ test('falls back to loopback on invalid IP header', async () => {
     headers: { 'x-real-ip': 'bad-ip' },
   })
   await rateLimit(req as any)
-  assert.ok(store.has('127.0.0.1'))
+  assert.ok(store.has('127.0.0.1:/'))
 })

--- a/Nutrishop/nutrishop-v2/src/lib/api-handler.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/api-handler.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { rateLimit } from './rate-limit'
+import { parseJsonBody } from './api-utils'
+import {
+  PayloadTooLargeError,
+  InvalidJsonError,
+  PAYLOAD_TOO_LARGE,
+  JSON_INVALIDE,
+  TOO_MANY_REQUESTS
+} from './errors'
+
+export function handleJsonRoute<T>(
+  handler: (json: T, req: NextRequest) => Promise<NextResponse>
+) {
+  return async (req: NextRequest) => {
+    const limit = await rateLimit(req)
+    if (!limit.ok) {
+      return NextResponse.json({ error: TOO_MANY_REQUESTS }, { status: 429 })
+    }
+    try {
+      const parsedReq = await parseJsonBody<T>(req)
+      if (!parsedReq.ok) {
+        return NextResponse.json({ error: 'Content-Type invalide' }, { status: 415 })
+      }
+      return await handler(parsedReq.data, req)
+    } catch (err) {
+      if (err instanceof PayloadTooLargeError) {
+        return NextResponse.json({ error: PAYLOAD_TOO_LARGE }, { status: 413 })
+      }
+      if (err instanceof InvalidJsonError) {
+        return NextResponse.json({ error: JSON_INVALIDE }, { status: 400 })
+      }
+      throw err
+    }
+  }
+}

--- a/Nutrishop/nutrishop-v2/src/lib/api-utils.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/api-utils.ts
@@ -4,9 +4,9 @@ import { parseJsonRequest } from './http'
 export const DEFAULT_MAX_JSON_SIZE = 1_000_000
 
 export async function parseJsonBody<T>(
-  req: Request | NextRequest,
+  req: NextRequest,
   options?: { maxBytes?: number }
 ) {
   const maxBytes = options?.maxBytes ?? DEFAULT_MAX_JSON_SIZE
-  return parseJsonRequest<T>(req as NextRequest, maxBytes)
+  return parseJsonRequest<T>(req, maxBytes)
 }

--- a/Nutrishop/nutrishop-v2/src/lib/http.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/http.ts
@@ -9,6 +9,14 @@ import {
   InvalidJsonError,
 } from './errors'
 
+export class ApiError extends Error {
+  status: number
+  constructor(status: number, message: string) {
+    super(message)
+    this.status = status
+  }
+}
+
 export async function readJsonBody<T>(
   req: NextRequest,
   maxBytes: number
@@ -57,16 +65,16 @@ export async function fetchJson<T>(
   const contentType = res.headers.get('content-type') || ''
   if (!contentType.includes('application/json')) {
     const text = await res.text().catch(() => '')
-    throw new Error(text || REPONSE_NON_JSON)
+    throw new ApiError(res.status, text || REPONSE_NON_JSON)
   }
   let data: T
   try {
     data = await res.json()
   } catch {
-    throw new Error(REPONSE_JSON_INVALIDE)
+    throw new ApiError(res.status, REPONSE_JSON_INVALIDE)
   }
   if (!res.ok) {
-    throw new Error((data as any)?.error || ERREUR_INCONNUE)
+    throw new ApiError(res.status, (data as any)?.error || ERREUR_INCONNUE)
   }
   return data
 }

--- a/Nutrishop/nutrishop-v2/src/lib/types/index.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/types/index.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod'
+import { isValidDate } from '../date-utils'
+
+export const registerSchema = z.object({
+  email: z.string().trim().email(),
+  username: z.string().trim().min(3),
+  password: z
+    .string()
+    .min(8)
+    .regex(/(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[^A-Za-z0-9])/, {
+      message:
+        'Le mot de passe doit contenir au moins 8 caractères avec majuscule, minuscule, chiffre et symbole'
+    })
+})
+
+export const requestSchema = z.object({
+  startDate: z.string().refine(isValidDate, {
+    message: 'Date de début invalide'
+  }),
+  endDate: z.string().refine(isValidDate, {
+    message: 'Date de fin invalide'
+  })
+})


### PR DESCRIPTION
## Summary
- centralize rate limiting and JSON parsing with `handleJsonRoute`
- share request schemas between client and server and add ApiError
- key rate limiting per route and update pages to handle structured errors

## Testing
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a819698970832bb14289ff452e14c9