### PR TITLE
feat: generate shopping list with fresh/dry categorization

### DIFF
--- a/Nutrishop/nutrishop-v2/prisma/schema.prisma
+++ b/Nutrishop/nutrishop-v2/prisma/schema.prisma
@@ -61,6 +61,7 @@ model Recipe {
   user         User     @relation(fields: [userId], references: [id])
   userId       String
   menuItems    MenuItem[]
+  ingredients  RecipeIngredient[]
 
   @@unique([userId, name])
 }
@@ -72,6 +73,7 @@ model Plan {
   startDate DateTime
   endDate   DateTime
   menuItems MenuItem[]
+  shoppingList ShoppingList?
 }
 
 model MenuItem {
@@ -82,4 +84,39 @@ model MenuItem {
   mealType String
   recipe   Recipe  @relation(fields: [recipeId], references: [id])
   recipeId String
+}
+
+model Ingredient {
+  id                String              @id @default(cuid())
+  name              String              @unique
+  category          String?
+  recipeIngredients RecipeIngredient[]
+  shoppingListItems ShoppingListItem[]
+}
+
+model RecipeIngredient {
+  id           String     @id @default(cuid())
+  recipe       Recipe     @relation(fields: [recipeId], references: [id])
+  recipeId     String
+  ingredient   Ingredient @relation(fields: [ingredientId], references: [id])
+  ingredientId String
+  quantity     Float
+  unit         String?
+}
+
+model ShoppingList {
+  id      String             @id @default(cuid())
+  plan    Plan               @relation(fields: [planId], references: [id])
+  planId  String             @unique
+  items   ShoppingListItem[]
+}
+
+model ShoppingListItem {
+  id             String        @id @default(cuid())
+  shoppingList   ShoppingList  @relation(fields: [shoppingListId], references: [id])
+  shoppingListId String
+  ingredient     Ingredient    @relation(fields: [ingredientId], references: [id])
+  ingredientId   String
+  quantity       Float
+  unit           String?
 }

--- a/Nutrishop/nutrishop-v2/src/app/api/shopping-list/route.ts
+++ b/Nutrishop/nutrishop-v2/src/app/api/shopping-list/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { authOptions } from '@/lib/auth'
+import { getSession } from '@/lib/session'
+import { handleJsonRoute } from '@/lib/api-handler'
+import { generateShoppingList } from '@/lib/shopping-list'
+
+const requestSchema = z.object({
+  planId: z.string()
+})
+
+export const POST = handleJsonRoute(async (json) => {
+  const session = await getSession(authOptions)
+  const userId = session?.user.id
+
+  if (!session || !userId) {
+    return NextResponse.json({ error: 'Non autorisé' }, { status: 401 })
+  }
+
+  const parsed = requestSchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Entrée invalide' }, { status: 400 })
+  }
+
+  try {
+    const list = await generateShoppingList(parsed.data.planId, userId)
+    const items = list.items.map((i) => ({
+      id: i.ingredientId,
+      name: i.ingredient.name,
+      quantity: i.quantity,
+      unit: i.unit,
+      category: i.ingredient.category
+    }))
+    return NextResponse.json({ items })
+  } catch (err) {
+    return NextResponse.json({ error: 'Échec de la génération' }, { status: 500 })
+  }
+})
+

--- a/Nutrishop/nutrishop-v2/src/lib/__tests__/optimizer.test.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/__tests__/optimizer.test.ts
@@ -8,6 +8,7 @@ import {
   namesMatch,
   optimizeShopping,
   UnknownUnitError,
+  classifyShoppingNeeds,
 } from '../optimizer'
 
 test('generateCombinations returns all combinations', () => {
@@ -131,4 +132,16 @@ test('namesMatch handles token order and minor differences', () => {
 
 test('namesMatch requires bidirectional token matches', () => {
   assert.ok(!namesMatch('sauce tomate', 'tomate'))
+})
+
+test('classifyShoppingNeeds splits fresh and dry', () => {
+  const needs = [
+    { id: '1', name: 'Lait', quantity: 1, unit: 'l' },
+    { id: '2', name: 'Pâtes', quantity: 500, unit: 'g' }
+  ]
+  const res = classifyShoppingNeeds(needs)
+  assert.equal(res.fresh.length, 1)
+  assert.equal(res.dry.length, 1)
+  assert.equal(res.fresh[0].id, '1')
+  assert.equal(needs[0].category, 'fresh')
 })

--- a/Nutrishop/nutrishop-v2/src/lib/optimizer.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/optimizer.ts
@@ -489,3 +489,43 @@ export function optimizeShopping(
 ): OptimizationResult {
   return findBestStoreCombination(needs, offers, maxStores)
 }
+
+// Séparer les besoins en produits frais ou secs
+const FRESH_KEYWORDS = [
+  'lait',
+  'oeuf',
+  'fromage',
+  'beurre',
+  'yaourt',
+  'viande',
+  'poulet',
+  'boeuf',
+  'poisson',
+  'fruit',
+  'légume'
+]
+
+export function classifyShoppingNeeds(needs: ShoppingNeed[]): {
+  fresh: ShoppingNeed[]
+  dry: ShoppingNeed[]
+} {
+  const fresh: ShoppingNeed[] = []
+  const dry: ShoppingNeed[] = []
+
+  for (const need of needs) {
+    const name = need.name.toLowerCase()
+    const category = need.category
+      ? need.category
+      : FRESH_KEYWORDS.some((k) => name.includes(k))
+        ? 'fresh'
+        : 'dry'
+    need.category = category
+    if (category === 'fresh') {
+      fresh.push(need)
+    } else {
+      dry.push(need)
+    }
+  }
+
+  return { fresh, dry }
+}

--- a/Nutrishop/nutrishop-v2/src/lib/shopping-list.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/shopping-list.ts
@@ -1,0 +1,89 @@
+import { getPrisma } from '@/lib/db'
+
+export interface ShoppingListItemInput {
+  ingredientId: string
+  name: string
+  quantity: number
+  unit: string | null
+  category?: string | null
+}
+
+export async function generateShoppingList(
+  planId: string,
+  userId: string
+) {
+  const prisma = getPrisma()
+
+  const plan = await prisma.plan.findFirst({
+    where: { id: planId, userId },
+    include: {
+      menuItems: {
+        include: {
+          recipe: {
+            include: {
+              ingredients: {
+                include: { ingredient: true }
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+
+  if (!plan) throw new Error('Plan not found')
+
+  const aggregated = new Map<string, ShoppingListItemInput>()
+
+  for (const item of plan.menuItems) {
+    for (const ri of item.recipe.ingredients) {
+      const key = `${ri.ingredientId}:${ri.unit || ''}`
+      const existing = aggregated.get(key)
+      if (existing) {
+        existing.quantity += ri.quantity
+      } else {
+        aggregated.set(key, {
+          ingredientId: ri.ingredientId,
+          name: ri.ingredient.name,
+          quantity: ri.quantity,
+          unit: ri.unit,
+          category: ri.ingredient.category
+        })
+      }
+    }
+  }
+
+  const list = await prisma.shoppingList.upsert({
+    where: { planId },
+    update: {
+      items: {
+        deleteMany: {},
+        create: Array.from(aggregated.values()).map((i) => ({
+          ingredientId: i.ingredientId,
+          quantity: i.quantity,
+          unit: i.unit
+        }))
+      }
+    },
+    create: {
+      planId,
+      items: {
+        create: Array.from(aggregated.values()).map((i) => ({
+          ingredientId: i.ingredientId,
+          quantity: i.quantity,
+          unit: i.unit
+        }))
+      }
+    },
+    include: {
+      items: { include: { ingredient: true } }
+    }
+  })
+
+  return list
+}
+
+export type GeneratedShoppingList = Awaited<
+  ReturnType<typeof generateShoppingList>
+>
+


### PR DESCRIPTION
## Summary
- define ingredient and shopping list models
- add shopping list generator and API route
- classify needs into fresh or dry categories
- test classification logic

## Testing
- `npm run db:migrate -- --name add-ingredients` (fails: Environment variable not found: DATABASE_URL)
- `npm run db:generate`
- `npm test` (fails: 22 tests failing)


------
https://chatgpt.com/codex/tasks/task_e_68a82fb75c48832ba198d0a6dcaf52e0