### PR TITLE
feat: unify error messages in French

### DIFF
--- a/Nutrishop/nutrishop-v2/src/app/api/ai/generate-plan/route.ts
+++ b/Nutrishop/nutrishop-v2/src/app/api/ai/generate-plan/route.ts
@@ -90,12 +90,7 @@ export const POST = handleJsonRoute(async (json, req: NextRequest) => {
   } catch (error) {
     logger.error({ err: error }, 'Erreur lors de la génération du plan repas')
     if (error instanceof GenerationError) {
-      const map: Record<string, string> = {
-        'Invalid meal plan format': 'Format du plan repas invalide',
-        'Gemini response too large': 'Réponse Gemini trop volumineuse',
-      }
-      const message = map[error.message] || 'Échec de la génération du plan repas'
-      return NextResponse.json({ error: message }, { status: 500 })
+      return NextResponse.json({ error: error.message }, { status: 500 })
     }
     return NextResponse.json(
       { error: 'Échec de la génération du plan repas' },

--- a/Nutrishop/nutrishop-v2/src/lib/__tests__/gemini.test.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/__tests__/gemini.test.ts
@@ -59,14 +59,14 @@ test('parseMealPlanResponse rejects non-object JSON', async () => {
   process.env.GOOGLE_API_KEY = 'test'
   process.env.GEMINI_MODEL = 'test-model'
   const { parseMealPlanResponse } = await import(modulePath)
-  assert.throws(() => parseMealPlanResponse('42'), /Invalid meal plan format/)
+  assert.throws(() => parseMealPlanResponse('42'), /Format du plan repas invalide/)
 })
 
 test('parseMealPlanResponse rejects arrays', async () => {
   process.env.GOOGLE_API_KEY = 'test'
   process.env.GEMINI_MODEL = 'test-model'
   const { parseMealPlanResponse } = await import(modulePath)
-  assert.throws(() => parseMealPlanResponse('[1,2,3]'), /Invalid meal plan format/)
+  assert.throws(() => parseMealPlanResponse('[1,2,3]'), /Format du plan repas invalide/)
 })
 
 test('generateMealPlan parses model response', async () => {
@@ -107,7 +107,7 @@ test('analyzeNutrition rejects incomplete data', async () => {
     }) as any
   } as any
   setModel(mockModel)
-  await assert.rejects(() => analyzeNutrition('bad'), /Invalid nutrition analysis format/)
+  await assert.rejects(() => analyzeNutrition('bad'), /Format de l'analyse nutritionnelle invalide/)
   setModel(null)
 })
 
@@ -120,7 +120,7 @@ test('generateMealPlan rejects oversized responses', async () => {
     generateContent: async () => ({ response: { text: () => large } }) as any
   } as any
   setModel(mockModel)
-  await assert.rejects(() => generateMealPlan('prompt'), /Gemini response too large/)
+  await assert.rejects(() => generateMealPlan('prompt'), /Réponse Gemini trop volumineuse/)
   setModel(null)
 })
 
@@ -133,6 +133,6 @@ test('analyzeNutrition rejects oversized responses', async () => {
     generateContent: async () => ({ response: { text: () => large } }) as any
   } as any
   setModel(mockModel)
-  await assert.rejects(() => analyzeNutrition('food'), /Gemini response too large/)
+  await assert.rejects(() => analyzeNutrition('food'), /Réponse Gemini trop volumineuse/)
   setModel(null)
 })

--- a/Nutrishop/nutrishop-v2/src/lib/gemini.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/gemini.ts
@@ -33,8 +33,8 @@ export function setModel(
 function getModel() {
   if (!model) {
     const { GOOGLE_API_KEY, GEMINI_MODEL } = getEnv()
-    if (!GOOGLE_API_KEY) throw new Error('GOOGLE_API_KEY is required')
-    if (!GEMINI_MODEL) throw new Error('GEMINI_MODEL is required')
+    if (!GOOGLE_API_KEY) throw new Error('GOOGLE_API_KEY est requis')
+    if (!GEMINI_MODEL) throw new Error('GEMINI_MODEL est requis')
     const genAI = new GoogleGenerativeAI(GOOGLE_API_KEY)
     model = genAI.getGenerativeModel({ model: GEMINI_MODEL })
   }
@@ -66,7 +66,7 @@ export function parseMealPlanResponse(text: string) {
     } catch {}
   }
 
-  throw new Error('Invalid meal plan format')
+  throw new Error('Format du plan repas invalide')
 }
 
 export async function generateMealPlan(prompt: string): Promise<MealPlan> {
@@ -75,24 +75,24 @@ export async function generateMealPlan(prompt: string): Promise<MealPlan> {
     const response = await result.response
     const text = response.text()
     if (text.length > MAX_RESPONSE_LENGTH) {
-      throw new Error('Gemini response too large')
+      throw new Error('Réponse Gemini trop volumineuse')
     }
     const data = parseMealPlanResponse(text)
     const parsed = mealPlanSchema.safeParse(data)
     if (!parsed.success) {
-      throw new Error('Invalid meal plan format')
+      throw new Error('Format du plan repas invalide')
     }
     return parsed.data
   } catch (error) {
-    logger.error({ err: error }, 'Error generating meal plan')
+    logger.error({ err: error }, 'Erreur lors de la génération du plan repas')
     if (
       error instanceof Error &&
-      (error.message === 'Invalid meal plan format' ||
-        error.message === 'Gemini response too large')
+      (error.message === 'Format du plan repas invalide' ||
+        error.message === 'Réponse Gemini trop volumineuse')
     ) {
       throw new GenerationError(error.message, { cause: error })
     }
-    throw new GenerationError('Failed to generate meal plan', { cause: error })
+    throw new GenerationError('Échec de la génération du plan repas', { cause: error })
   }
 }
 
@@ -118,29 +118,29 @@ export async function analyzeNutrition(foodDescription: string): Promise<Nutriti
     const response = await result.response
     const text = response.text()
     if (text.length > MAX_RESPONSE_LENGTH) {
-      throw new Error('Gemini response too large')
+      throw new Error('Réponse Gemini trop volumineuse')
     }
 
     let data: unknown
     try {
       data = parseMealPlanResponse(text)
     } catch {
-      throw new Error('Invalid nutrition analysis format')
+      throw new Error("Format de l'analyse nutritionnelle invalide")
     }
     const parsed = nutritionSchema.safeParse(data)
     if (!parsed.success) {
-      throw new Error('Invalid nutrition analysis format')
+      throw new Error("Format de l'analyse nutritionnelle invalide")
     }
     return parsed.data
   } catch (error) {
-    logger.error({ err: error }, 'Error analyzing nutrition')
+    logger.error({ err: error }, "Erreur lors de l'analyse nutritionnelle")
     if (
       error instanceof Error &&
-      (error.message === 'Invalid nutrition analysis format' ||
-        error.message === 'Gemini response too large')
+      (error.message === "Format de l'analyse nutritionnelle invalide" ||
+        error.message === 'Réponse Gemini trop volumineuse')
     ) {
       throw new NutritionError(error.message, { cause: error })
     }
-    throw new NutritionError('Failed to analyze nutrition', { cause: error })
+    throw new NutritionError("Échec de l'analyse nutritionnelle", { cause: error })
   }
 }


### PR DESCRIPTION
## Summary
- standardize Gemini helper and generate-plan API to use French error messages
- simplify API route error mapping and surface GenerationError messages directly
- adjust tests for new French error responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa2c0f87dc832bb06649850b5fc5d5