### PR TITLE
Remove userId requirement from meal and shopping routes

### DIFF
--- a/Nutrishop/nutrishop-v2/src/app/api/shopping-list/route.ts
+++ b/Nutrishop/nutrishop-v2/src/app/api/shopping-list/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
-import { authOptions } from '@/lib/auth'
-import { getSession } from '@/lib/session'
 import { handleJsonRoute } from '@/lib/api-handler'
 import { generateShoppingList } from '@/lib/shopping-list'
 
@@ -10,12 +8,6 @@ const requestSchema = z.object({
 })
 
 export const POST = handleJsonRoute(async (json) => {
-  const session = await getSession(authOptions)
-  const userId = session?.user.id
-
-  if (!session || !userId) {
-    return NextResponse.json({ error: 'Non autorisé' }, { status: 401 })
-  }
 
   const parsed = requestSchema.safeParse(json)
   if (!parsed.success) {
@@ -23,7 +15,7 @@ export const POST = handleJsonRoute(async (json) => {
   }
 
   try {
-    const list = await generateShoppingList(parsed.data.planId, userId)
+    const list = await generateShoppingList(parsed.data.planId)
     const items = list.items.map((i) => ({
       id: i.ingredientId,
       name: i.ingredient.name,

--- a/Nutrishop/nutrishop-v2/src/lib/__tests__/generate-plan.test.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/__tests__/generate-plan.test.ts
@@ -90,14 +90,12 @@ test('saveMealPlan avoids duplicate recipe errors', async () => {
   await utils.saveMealPlan(
     mealPlan as any,
     { cuisineType: 'classique' },
-    '1',
     '2024-01-01',
     '2024-01-02',
   )
   assert.deepEqual(upsertArgs.where, {
-    userId_name: { userId: '1', name: 'Omelette' },
+    name: 'Omelette',
   })
-  assert.equal(upsertArgs.create.userId, '1')
 })
 
 test('saveMealPlan processes all meals', async () => {
@@ -122,7 +120,6 @@ test('saveMealPlan processes all meals', async () => {
   await utils.saveMealPlan(
     mealPlan as any,
     { cuisineType: 'classique' },
-    '1',
     '2024-01-01',
     '2024-01-02',
   )
@@ -163,7 +160,6 @@ test('saveMealPlan throws on out-of-range plan', async () => {
       utils.saveMealPlan(
         mealPlan as any,
         { cuisineType: 'classique' },
-        '1',
         '2024-01-02',
         '2024-01-01',
       ),

--- a/Nutrishop/nutrishop-v2/src/lib/meal-plan.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/meal-plan.ts
@@ -82,7 +82,6 @@ export async function saveMealPlan(
     }>
   },
   profile: MealPlanProfile,
-  userId: string,
   startDate: string,
   endDate: string,
 ) {
@@ -93,7 +92,6 @@ export async function saveMealPlan(
   return prisma.$transaction(async (tx) => {
     const plan = await tx.plan.create({
       data: {
-        userId,
         startDate: parseISO(startDate),
         endDate: parseISO(endDate),
       },
@@ -120,9 +118,9 @@ export async function saveMealPlan(
         }
 
         const recipe = await tx.recipe.upsert({
-          where: { userId_name: { userId, name: meal.name } },
+          where: { name: meal.name },
           update: recipeData,
-          create: { userId, name: meal.name, ...recipeData },
+          create: { name: meal.name, ...recipeData },
         })
 
         await tx.menuItem.create({

--- a/Nutrishop/nutrishop-v2/src/lib/shopping-list.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/shopping-list.ts
@@ -8,11 +8,11 @@ export interface ShoppingListItemInput {
   category?: string | null
 }
 
-export async function generateShoppingList(planId: string, userId: string) {
+export async function generateShoppingList(planId: string) {
   const prisma = getPrisma()
 
   const plan = await prisma.plan.findFirst({
-    where: { id: planId, userId },
+    where: { id: planId },
     include: {
       menuItems: {
         include: {


### PR DESCRIPTION
## Summary
- drop session and userId requirement from meal plan and shopping list APIs
- update meal-plan and shopping-list helpers to work without userId
- adjust tests for updated function signatures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aeac8624fc832b9f3b01f7ba501c1d