### PR TITLE
refactor: remove user model

### DIFF
--- a/Nutrishop/nutrishop-v2/prisma/schema.prisma
+++ b/Nutrishop/nutrishop-v2/prisma/schema.prisma
@@ -7,21 +7,8 @@ generator client {
   provider = "prisma-client-js"
 }
 
-model User {
-  id                 String   @id @default(cuid())
-  email              String   @unique
-  username           String
-  usernameNormalized String   @unique
-  password           String
-  profile            Profile?
-  plans              Plan[]
-  recipes            Recipe[]
-}
-
 model Profile {
   id           String               @id @default(cuid())
-  user         User                 @relation(fields: [userId], references: [id])
-  userId       String   @unique
   cuisineType  String?
   appliances   ProfileAppliance[]
 }
@@ -42,7 +29,7 @@ model ProfileAppliance {
 
 model Recipe {
   id           String   @id @default(cuid())
-  name         String
+  name         String   @unique
   description  String?
   instructions String?
   prepTime     Int?
@@ -58,18 +45,12 @@ model Recipe {
   sodium       Float?
   tags         String[]
   category     String?
-  user         User     @relation(fields: [userId], references: [id])
-  userId       String
   menuItems    MenuItem[]
   ingredients  RecipeIngredient[]
-
-  @@unique([userId, name])
 }
 
 model Plan {
   id        String     @id @default(cuid())
-  user      User       @relation(fields: [userId], references: [id])
-  userId    String
   startDate DateTime
   endDate   DateTime
   menuItems MenuItem[]

--- a/Nutrishop/nutrishop-v2/src/app/api/ai/generate-plan/route.ts
+++ b/Nutrishop/nutrishop-v2/src/app/api/ai/generate-plan/route.ts
@@ -14,9 +14,7 @@ import { logger } from '@/lib/logger'
 export const POST = handleJsonRoute(async (json, req: NextRequest) => {
   try {
     const session = await getSession(authOptions)
-    const userId = session?.user.id
-
-    if (!session || !userId) {
+    if (!session?.user?.id) {
       return NextResponse.json({ error: 'Non autorisé' }, { status: 401 })
     }
 
@@ -46,8 +44,7 @@ export const POST = handleJsonRoute(async (json, req: NextRequest) => {
     }
 
     const prisma = getPrisma()
-    const profile = await prisma.profile.findUnique({
-      where: { userId },
+    const profile = await prisma.profile.findFirst({
       include: {
         appliances: {
           include: {
@@ -89,7 +86,6 @@ export const POST = handleJsonRoute(async (json, req: NextRequest) => {
     const plan = await saveMealPlan(
       mealPlan,
       { cuisineType: profile.cuisineType ?? undefined },
-      userId,
       startDate,
       endDate,
     )

--- a/Nutrishop/nutrishop-v2/src/app/api/shopping-list/route.ts
+++ b/Nutrishop/nutrishop-v2/src/app/api/shopping-list/route.ts
@@ -11,9 +11,7 @@ const requestSchema = z.object({
 
 export const POST = handleJsonRoute(async (json) => {
   const session = await getSession(authOptions)
-  const userId = session?.user.id
-
-  if (!session || !userId) {
+  if (!session?.user?.id) {
     return NextResponse.json({ error: 'Non autorisé' }, { status: 401 })
   }
 
@@ -23,7 +21,7 @@ export const POST = handleJsonRoute(async (json) => {
   }
 
   try {
-    const list = await generateShoppingList(parsed.data.planId, userId)
+    const list = await generateShoppingList(parsed.data.planId)
     const items = list.items.map((i) => ({
       id: i.ingredientId,
       name: i.ingredient.name,

--- a/Nutrishop/nutrishop-v2/src/lib/__tests__/generate-plan.test.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/__tests__/generate-plan.test.ts
@@ -90,14 +90,13 @@ test('saveMealPlan avoids duplicate recipe errors', async () => {
   await utils.saveMealPlan(
     mealPlan as any,
     { cuisineType: 'classique' },
-    '1',
     '2024-01-01',
     '2024-01-02',
   )
   assert.deepEqual(upsertArgs.where, {
-    userId_name: { userId: '1', name: 'Omelette' },
+    name: 'Omelette',
   })
-  assert.equal(upsertArgs.create.userId, '1')
+  assert.equal(upsertArgs.create.name, 'Omelette')
 })
 
 test('saveMealPlan processes all meals', async () => {
@@ -122,7 +121,6 @@ test('saveMealPlan processes all meals', async () => {
   await utils.saveMealPlan(
     mealPlan as any,
     { cuisineType: 'classique' },
-    '1',
     '2024-01-01',
     '2024-01-02',
   )
@@ -163,7 +161,6 @@ test('saveMealPlan throws on out-of-range plan', async () => {
       utils.saveMealPlan(
         mealPlan as any,
         { cuisineType: 'classique' },
-        '1',
         '2024-01-02',
         '2024-01-01',
       ),
@@ -234,7 +231,7 @@ test('allows ranges up to 90 days', async () => {
     user: { id: '1', email: 'a@a.com', name: 'user' },
   }))
   ;(prisma as any).profile = {
-    findUnique: async () => ({ cuisineType: null, appliances: [] }),
+    findFirst: async () => ({ cuisineType: null, appliances: [] }),
   }
   ;(prisma as any).$transaction = async (cb: any) => {
     return cb({

--- a/Nutrishop/nutrishop-v2/src/lib/meal-plan.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/meal-plan.ts
@@ -82,7 +82,6 @@ export async function saveMealPlan(
     }>
   },
   profile: MealPlanProfile,
-  userId: string,
   startDate: string,
   endDate: string,
 ) {
@@ -93,7 +92,6 @@ export async function saveMealPlan(
   return prisma.$transaction(async (tx) => {
     const plan = await tx.plan.create({
       data: {
-        userId,
         startDate: parseISO(startDate),
         endDate: parseISO(endDate),
       },
@@ -120,9 +118,9 @@ export async function saveMealPlan(
         }
 
         const recipe = await tx.recipe.upsert({
-          where: { userId_name: { userId, name: meal.name } },
+          where: { name: meal.name },
           update: recipeData,
-          create: { userId, name: meal.name, ...recipeData },
+          create: { name: meal.name, ...recipeData },
         })
 
         await tx.menuItem.create({

--- a/Nutrishop/nutrishop-v2/src/lib/shopping-list.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/shopping-list.ts
@@ -8,11 +8,11 @@ export interface ShoppingListItemInput {
   category?: string | null
 }
 
-export async function generateShoppingList(planId: string, userId: string) {
+export async function generateShoppingList(planId: string) {
   const prisma = getPrisma()
 
   const plan = await prisma.plan.findFirst({
-    where: { id: planId, userId },
+    where: { id: planId },
     include: {
       menuItems: {
         include: {


### PR DESCRIPTION
## Summary
- drop User model and userId references from schema
- update meal plan and shopping list logic to work without user IDs
- adjust API routes and tests for new schema

## Testing
- `DATABASE_URL=postgresql://user:pass@localhost:5432/test npx prisma migrate dev --name remove-user` (fails: Can't reach database server at `localhost:5432`)
- `DATABASE_URL=postgresql://user:pass@localhost:5432/test GOOGLE_API_KEY=dummy GEMINI_MODEL=test-model npx tsx --test src/lib/__tests__/*.test.ts` (fails: 57 passed, 7 failed)


------
https://chatgpt.com/codex/tasks/task_e_68aeac87116c832bb35c3d5432a3cddc