### PR TITLE
Remove authentication links from navigation

### DIFF
--- a/Nutrishop/nutrishop-v2/src/app/page.tsx
+++ b/Nutrishop/nutrishop-v2/src/app/page.tsx
@@ -4,9 +4,6 @@ export default function Home() {
       <h1>Nutrishop</h1>
       <ul>
         <li>
-          <a href="/register">Inscription</a>
-        </li>
-        <li>
           <a href="/plan">Plan repas</a>
         </li>
       </ul>


### PR DESCRIPTION
## Summary
- remove registration link from home page navigation

## Testing
- `npm test`
- `npm run type-check` *(fails: Property 'baseUnit' does not exist on type 'UnknownUnitError')*


------
https://chatgpt.com/codex/tasks/task_e_68aeac88ef4c832b927214ac35667749