### PR TITLE
Remove custom logger and use console

### DIFF
--- a/Nutrishop/nutrishop-v2/src/app/api/ai/generate-plan/route.ts
+++ b/Nutrishop/nutrishop-v2/src/app/api/ai/generate-plan/route.ts
@@ -7,7 +7,6 @@ import { differenceInCalendarDays, parseISO } from 'date-fns'
 import { datesWithinRange, saveMealPlan } from '@/lib/meal-plan'
 import { handleJsonRoute } from '@/lib/api-handler'
 import { requestSchema } from '@/lib/types'
-import { logger } from '@/lib/logger'
 
 export const POST = handleJsonRoute(async (json, req: NextRequest) => {
   try {
@@ -89,7 +88,7 @@ export const POST = handleJsonRoute(async (json, req: NextRequest) => {
       mealPlan,
     })
   } catch (error) {
-    logger.error({ err: error }, 'Erreur lors de la génération du plan repas')
+    console.error({ err: error }, 'Erreur lors de la génération du plan repas')
     if (error instanceof GenerationError) {
       const message = error.message || 'Échec de la génération du plan repas'
       return NextResponse.json({ error: message }, { status: 500 })

--- a/Nutrishop/nutrishop-v2/src/lib/gemini.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/gemini.ts
@@ -4,7 +4,6 @@ import extract from 'extract-json-from-string'
 import { jsonrepair } from 'jsonrepair'
 import { getEnv } from './config'
 import { mealPlanSchema, type MealPlan } from './meal-plan'
-import { logger } from './logger'
 
 export class GenerationError extends Error {
   constructor(message: string, options?: { cause?: unknown }) {
@@ -84,7 +83,7 @@ export async function generateMealPlan(prompt: string): Promise<MealPlan> {
     }
     return parsed.data
   } catch (error) {
-    logger.error({ err: error }, 'Erreur lors de la génération du plan repas')
+    console.error({ err: error }, 'Erreur lors de la génération du plan repas')
     if (
       error instanceof Error &&
       (error.message === 'Format du plan repas invalide' ||
@@ -137,7 +136,7 @@ export async function analyzeNutrition(
     }
     return parsed.data
   } catch (error) {
-    logger.error({ err: error }, "Erreur lors de l'analyse nutritionnelle")
+    console.error({ err: error }, "Erreur lors de l'analyse nutritionnelle")
     if (
       error instanceof Error &&
       (error.message === "Format d'analyse nutritionnelle invalide" ||

--- a/Nutrishop/nutrishop-v2/src/lib/logger.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/logger.ts
@@ -1,7 +1,0 @@
-import pino from 'pino'
-
-export const logger = pino({
-  level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
-})
-
-export default logger


### PR DESCRIPTION
## Summary
- drop unused logger utility and rely on console
- replace logger.error calls with console.error in Gemini and plan generation API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeb5ed659c832b93768724bfc4d14a