### PR TITLE
simplify gemini integration

### DIFF
--- a/Nutrishop/nutrishop-v2/package-lock.json
+++ b/Nutrishop/nutrishop-v2/package-lock.json
@@ -25,7 +25,6 @@
         "jsonrepair": "^3.13.0",
         "lucide-react": "^0.294.0",
         "next": "14.2.32",
-        "pino": "^8.19.0",
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.48.2",
@@ -2545,18 +2544,6 @@
         "win32"
       ]
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2852,15 +2839,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/atomic-sleep": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
-      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -2941,26 +2919,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3027,30 +2985,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/busboy": {
@@ -4329,29 +4263,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
     },
     "node_modules/extract-json-from-string": {
       "version": "1.0.1",
@@ -4419,15 +4335,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-redact": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -4873,26 +4780,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -5996,15 +5883,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/on-exit-leak-free": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
-      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6186,44 +6064,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/pino": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
-      "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.1.1",
-        "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^1.2.0",
-        "pino-std-serializers": "^6.0.0",
-        "process-warning": "^3.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.2.0",
-        "safe-stable-stringify": "^2.3.1",
-        "sonic-boom": "^3.7.0",
-        "thread-stream": "^2.6.0"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "node_modules/pino-abstract-transport": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
-      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^4.0.0",
-        "split2": "^4.0.0"
-      }
-    },
-    "node_modules/pino-std-serializers": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
-      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
-      "license": "MIT"
-    },
     "node_modules/pirates": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
@@ -6397,21 +6237,6 @@
         "fsevents": "2.3.3"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/process-warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
-      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
-      "license": "MIT"
-    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6451,12 +6276,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
-    },
-    "node_modules/quick-format-unescaped": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
-      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
     "node_modules/react": {
@@ -6615,22 +6434,6 @@
         "pify": "^2.3.0"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -6641,15 +6444,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/real-require": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
-      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.13.0"
       }
     },
     "node_modules/recharts": {
@@ -6844,26 +6638,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -6897,15 +6671,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/safe-stable-stringify": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
-      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/scheduler": {
@@ -7088,15 +6853,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/sonic-boom": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
-      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7104,15 +6860,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/split2": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 10.x"
       }
     },
     "node_modules/stable-hash": {
@@ -7142,15 +6889,6 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -7619,15 +7357,6 @@
       },
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/thread-stream": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
-      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
-      "license": "MIT",
-      "dependencies": {
-        "real-require": "^0.2.0"
       }
     },
     "node_modules/tiny-invariant": {

--- a/Nutrishop/nutrishop-v2/package.json
+++ b/Nutrishop/nutrishop-v2/package.json
@@ -12,7 +12,7 @@
     "db:studio": "prisma studio",
     "db:seed": "tsx src/lib/seed.ts",
     "type-check": "tsc --noEmit",
-    "test": "DATABASE_URL=postgresql://user:pass@localhost:5432/test GOOGLE_API_KEY=dummy GEMINI_MODEL=test-model node --test -r tsx src/lib/__tests__/*.test.ts",
+    "test": "DATABASE_URL=postgresql://user:pass@localhost:5432/test GEMINI_API_KEY=dummy node --test --import tsx src/lib/__tests__/*.test.ts",
     "format": "prettier --write ."
   },
   "dependencies": {
@@ -33,7 +33,6 @@
     "jsonrepair": "^3.13.0",
     "lucide-react": "^0.294.0",
     "next": "14.2.32",
-    "pino": "^8.19.0",
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.48.2",

--- a/Nutrishop/nutrishop-v2/src/app/api/ai/generate-plan/route.ts
+++ b/Nutrishop/nutrishop-v2/src/app/api/ai/generate-plan/route.ts
@@ -7,7 +7,6 @@ import { differenceInCalendarDays, parseISO } from 'date-fns'
 import { datesWithinRange, saveMealPlan } from '@/lib/meal-plan'
 import { handleJsonRoute } from '@/lib/api-handler'
 import { requestSchema } from '@/lib/types'
-import { logger } from '@/lib/logger'
 
 export const POST = handleJsonRoute(async (json, req: NextRequest) => {
   try {
@@ -89,7 +88,7 @@ export const POST = handleJsonRoute(async (json, req: NextRequest) => {
       mealPlan,
     })
   } catch (error) {
-    logger.error({ err: error }, 'Erreur lors de la génération du plan repas')
+    console.error('Erreur lors de la génération du plan repas', error)
     if (error instanceof GenerationError) {
       const message = error.message || 'Échec de la génération du plan repas'
       return NextResponse.json({ error: message }, { status: 500 })

--- a/Nutrishop/nutrishop-v2/src/lib/__tests__/gemini.test.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/__tests__/gemini.test.ts
@@ -8,95 +8,28 @@ const modulePath = '../gemini'
 test('imports without env vars', () => {
   const result = spawnSync(
     process.execPath,
-    ['-r', 'tsx', '-e', "import('./src/lib/gemini.ts')"],
+    ['--import', 'tsx', '-e', "import('./src/lib/gemini.ts')"],
     {
-      env: { ...process.env, GOOGLE_API_KEY: '', GEMINI_MODEL: '' },
+      env: { ...process.env, GEMINI_API_KEY: '' },
     },
   )
   assert.equal(result.status, 0)
 })
 
-test('parseMealPlanResponse extracts first JSON', async () => {
-  process.env.GOOGLE_API_KEY = 'test'
-  process.env.GEMINI_MODEL = 'test-model'
-  const { parseMealPlanResponse } = await import(modulePath)
-  const data = parseMealPlanResponse('foo {"days": []} bar {"other": 1}')
-  assert.deepEqual(data, { days: [] })
-})
-
-test('parseMealPlanResponse handles nested JSON', async () => {
-  process.env.GOOGLE_API_KEY = 'test'
-  process.env.GEMINI_MODEL = 'test-model'
-  const { parseMealPlanResponse } = await import(modulePath)
-  const text = 'start {"a": {"b": [1, 2, {"c": 3}]}} end'
-  const data = parseMealPlanResponse(text)
-  assert.deepEqual(data, { a: { b: [1, 2, { c: 3 }] } })
-})
-
-test('parseMealPlanResponse strips code fences and extra text', async () => {
-  process.env.GOOGLE_API_KEY = 'test'
-  process.env.GEMINI_MODEL = 'test-model'
-  const { parseMealPlanResponse } = await import(modulePath)
-  const response = '```json\n{"days": []}\n``` noise'
-  const data = parseMealPlanResponse(response)
-  assert.deepEqual(data, { days: [] })
-})
-
-test('parseMealPlanResponse handles braces inside strings', async () => {
-  process.env.GOOGLE_API_KEY = 'test'
-  process.env.GEMINI_MODEL = 'test-model'
-  const { parseMealPlanResponse } = await import(modulePath)
-  const text = '{"a": "value with { brace", "b": 1}'
-  const data = parseMealPlanResponse(text)
-  assert.deepEqual(data, { a: 'value with { brace', b: 1 })
-})
-
-test('parseMealPlanResponse repairs malformed JSON', async () => {
-  process.env.GOOGLE_API_KEY = 'test'
-  process.env.GEMINI_MODEL = 'test-model'
-  const { parseMealPlanResponse } = await import(modulePath)
-  const data = parseMealPlanResponse('noise {a:1,} more')
-  assert.deepEqual(data, { a: 1 })
-})
-
-test('parseMealPlanResponse rejects non-object JSON', async () => {
-  process.env.GOOGLE_API_KEY = 'test'
-  process.env.GEMINI_MODEL = 'test-model'
-  const { parseMealPlanResponse } = await import(modulePath)
-  assert.throws(
-    () => parseMealPlanResponse('42'),
-    /Format du plan repas invalide/,
-  )
-})
-
-test('parseMealPlanResponse rejects arrays', async () => {
-  process.env.GOOGLE_API_KEY = 'test'
-  process.env.GEMINI_MODEL = 'test-model'
-  const { parseMealPlanResponse } = await import(modulePath)
-  assert.throws(
-    () => parseMealPlanResponse('[1,2,3]'),
-    /Format du plan repas invalide/,
-  )
-})
-
 test('generateMealPlan parses model response', async () => {
-  process.env.GOOGLE_API_KEY = 'test'
-  process.env.GEMINI_MODEL = 'test-model'
-  const { generateMealPlan, setModel } = await import(modulePath)
+  process.env.GEMINI_API_KEY = 'test'
+  const { generateMealPlan } = await import(modulePath)
   const mockModel: ReturnType<GoogleGenerativeAI['getGenerativeModel']> = {
     generateContent: async () =>
       ({ response: { text: () => '{"days":[]}' } }) as any,
   } as any
-  setModel(mockModel)
-  const result = await generateMealPlan('prompt')
+  const result = await generateMealPlan('prompt', mockModel)
   assert.deepEqual(result, { days: [] })
-  setModel(null)
 })
 
 test('analyzeNutrition parses model response', async () => {
-  process.env.GOOGLE_API_KEY = 'test'
-  process.env.GEMINI_MODEL = 'test-model'
-  const { analyzeNutrition, setModel } = await import(modulePath)
+  process.env.GEMINI_API_KEY = 'test'
+  const { analyzeNutrition } = await import(modulePath)
   const mockModel: ReturnType<GoogleGenerativeAI['getGenerativeModel']> = {
     generateContent: async () =>
       ({
@@ -106,8 +39,7 @@ test('analyzeNutrition parses model response', async () => {
         },
       }) as any,
   } as any
-  setModel(mockModel)
-  const result = await analyzeNutrition('test food')
+  const result = await analyzeNutrition('test food', mockModel)
   assert.deepEqual(result, {
     kcal: 100,
     protein: 1,
@@ -117,59 +49,45 @@ test('analyzeNutrition parses model response', async () => {
     sugar: 5,
     sodium: 6,
   })
-  setModel(null)
 })
 
 test('analyzeNutrition rejects incomplete data', async () => {
-  process.env.GOOGLE_API_KEY = 'test'
-  process.env.GEMINI_MODEL = 'test-model'
-  const { analyzeNutrition, setModel } = await import(modulePath)
+  process.env.GEMINI_API_KEY = 'test'
+  const { analyzeNutrition } = await import(modulePath)
   const mockModel: ReturnType<GoogleGenerativeAI['getGenerativeModel']> = {
     generateContent: async () =>
       ({
         response: { text: () => '{"kcal":100}' },
       }) as any,
   } as any
-  setModel(mockModel)
   await assert.rejects(
-    () => analyzeNutrition('bad'),
+    () => analyzeNutrition('bad', mockModel),
     /Format d'analyse nutritionnelle invalide/,
   )
-  setModel(null)
 })
 
 test('generateMealPlan rejects oversized responses', async () => {
-  process.env.GOOGLE_API_KEY = 'test'
-  process.env.GEMINI_MODEL = 'test-model'
-  const { generateMealPlan, setModel, MAX_RESPONSE_LENGTH } = await import(
-    modulePath
-  )
+  process.env.GEMINI_API_KEY = 'test'
+  const { generateMealPlan, MAX_RESPONSE_LENGTH } = await import(modulePath)
   const large = 'a'.repeat(MAX_RESPONSE_LENGTH + 1)
   const mockModel: ReturnType<GoogleGenerativeAI['getGenerativeModel']> = {
     generateContent: async () => ({ response: { text: () => large } }) as any,
   } as any
-  setModel(mockModel)
   await assert.rejects(
-    () => generateMealPlan('prompt'),
+    () => generateMealPlan('prompt', mockModel),
     /Réponse Gemini trop volumineuse/,
   )
-  setModel(null)
 })
 
 test('analyzeNutrition rejects oversized responses', async () => {
-  process.env.GOOGLE_API_KEY = 'test'
-  process.env.GEMINI_MODEL = 'test-model'
-  const { analyzeNutrition, setModel, MAX_RESPONSE_LENGTH } = await import(
-    modulePath
-  )
+  process.env.GEMINI_API_KEY = 'test'
+  const { analyzeNutrition, MAX_RESPONSE_LENGTH } = await import(modulePath)
   const large = 'a'.repeat(MAX_RESPONSE_LENGTH + 1)
   const mockModel: ReturnType<GoogleGenerativeAI['getGenerativeModel']> = {
     generateContent: async () => ({ response: { text: () => large } }) as any,
   } as any
-  setModel(mockModel)
   await assert.rejects(
-    () => analyzeNutrition('food'),
+    () => analyzeNutrition('food', mockModel),
     /Réponse Gemini trop volumineuse/,
   )
-  setModel(null)
 })

--- a/Nutrishop/nutrishop-v2/src/lib/config.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/config.ts
@@ -2,8 +2,6 @@ import { z } from 'zod'
 
 const envSchema = z.object({
   DATABASE_URL: z.string().optional(),
-  GOOGLE_API_KEY: z.string().optional(),
-  GEMINI_MODEL: z.string().optional(),
   MAX_STORE_COMBINATIONS: z.coerce.number().int().positive().default(5000),
 })
 

--- a/Nutrishop/nutrishop-v2/src/lib/logger.ts
+++ b/Nutrishop/nutrishop-v2/src/lib/logger.ts
@@ -1,7 +1,0 @@
-import pino from 'pino'
-
-export const logger = pino({
-  level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
-})
-
-export default logger


### PR DESCRIPTION
## Summary
- remove logger dependency and pino package
- access Gemini directly via `process.env.GEMINI_API_KEY` with fixed model
- streamline gemini module exports and update tests for Node 22

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aeb5efeb94832bb75955e5ff23e7a7