### PR TITLE
Simplify plan page error handling

### DIFF
--- a/Nutrishop/nutrishop-v2/src/app/plan/page.tsx
+++ b/Nutrishop/nutrishop-v2/src/app/plan/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { fetchJson, ApiError } from '@/lib/http'
+import { fetchJson } from '@/lib/http'
 import { requestSchema } from '@/lib/types'
 import type { z } from 'zod'
 
@@ -14,7 +14,6 @@ interface PlanResponse {
 
 export default function PlanPage() {
   const [form, setForm] = useState<PlanRequest>({ startDate: '', endDate: '' })
-  const [error, setError] = useState<string | null>(null)
   const [result, setResult] = useState<any>(null)
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -23,16 +22,7 @@ export default function PlanPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    setError(null)
     setResult(null)
-    if (!form.startDate || !form.endDate) {
-      setError('Les deux dates sont requises')
-      return
-    }
-    if (form.startDate > form.endDate) {
-      setError('La date de début doit précéder la date de fin')
-      return
-    }
     try {
       const data = await fetchJson<PlanResponse>('/api/ai/generate-plan', {
         method: 'POST',
@@ -40,12 +30,8 @@ export default function PlanPage() {
         body: JSON.stringify(form),
       })
       setResult(data)
-    } catch (err) {
-      if (err instanceof ApiError) {
-        setError(err.status >= 500 ? 'Erreur serveur' : err.message)
-      } else {
-        setError('Erreur inconnue')
-      }
+    } catch {
+      alert('Impossible de générer le plan')
     }
   }
 
@@ -58,20 +44,15 @@ export default function PlanPage() {
           name="startDate"
           value={form.startDate}
           onChange={handleChange}
-          required
-          max={form.endDate || undefined}
         />
         <input
           type="date"
           name="endDate"
           value={form.endDate}
           onChange={handleChange}
-          required
-          min={form.startDate || undefined}
         />
         <button type="submit">Envoyer</button>
       </form>
-      {error && <p>{error}</p>}
       {result && <pre>{JSON.stringify(result, null, 2)}</pre>}
     </main>
   )


### PR DESCRIPTION
## Summary
- simplify plan generation page error handling with an alert
- drop client-side form validations handled by server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aeb5f2f370832b828b2f8627fe6d7c